### PR TITLE
Override pretty_print to redact when pretty-printed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+## [1.1.0] - 2021-03-24
+
+- Override `Struct#pretty_print` to keep redacted fields redacted when
+  pretty-printing via `pp`
+
 ## [1.0.0] - 2021-03-24
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -8,12 +8,28 @@ Config = RedactedStruct.new(
   :username,
   :password,
   :timeout,
+  :url,
   keyword_init: true,
   allowed_members: [:username, :timeout]
 )
 
-Config.new(username: 'example', password: 'secret', timeout: 5)
+config = Config.new(username: 'example', password: 'secret', timeout: 5, url: 'https://example.com')
 => #<struct Config username="example" password=[REDACTED] timeout=5>
+```
+
+## Pretty-Printing
+
+The struct will automatically redact itself when pretty-printed via `#pp`:
+
+```ruby
+require 'pp'
+
+pp config
+#<struct Config
+ username="example",
+ password=[REDACTED],
+ timeout=5,
+ url="https://example.com">
 ```
 
 ## Installation

--- a/lib/redacted_struct.rb
+++ b/lib/redacted_struct.rb
@@ -2,7 +2,7 @@
 
 # A subclass of Struct that redacts members by default, and can allow some to be printed
 class RedactedStruct < Struct
-  VERSION = "1.0.1"
+  VERSION = "1.1.0"
 
   def self.new(*name_and_members, keyword_init: nil, allowed_members: [], &block)
     super(*name_and_members, keyword_init: keyword_init, &block).tap do |struct_class|
@@ -35,4 +35,26 @@ class RedactedStruct < Struct
   end
 
   alias_method :to_s, :inspect
+
+  # Overrides for pp
+  # See https://github.com/ruby/pp/blob/3d925b5688b8226f653127d990a8dce48bced5fe/lib/pp.rb#L379-L391
+  # rubocop:disable all
+  def pretty_print(q)
+    q.group(1, sprintf("#<struct %s", PP.mcall(self, Kernel, :class).name), '>') {
+      q.seplist(PP.mcall(self, Struct, :members), lambda { q.text "," }) {|member|
+        q.breakable
+        q.text member.to_s
+        q.text '='
+        q.group(1) {
+          q.breakable ''
+          if allowed_members.include?(member)
+            q.pp self[member]
+          else
+            q.text "[REDACTED]"
+          end
+        }
+      }
+    }
+  end
+  # rubocop:enable all
 end

--- a/spec/redacted_struct_spec.rb
+++ b/spec/redacted_struct_spec.rb
@@ -119,4 +119,23 @@ RSpec.describe RedactedStruct do
       )
     end
   end
+
+  describe "#pp/#pretty_inspect" do
+    require "pp"
+
+    it "redacts when pretty printed" do
+      io = StringIO.new
+
+      PP.pp instance, io, 30
+
+      # rubocop:disable Layout/TrailingWhitespace
+      expect(io.string).to eq <<~STR
+        #<struct 
+         username="example",
+         password=[REDACTED],
+         api_key=[REDACTED]>
+      STR
+      # rubocop:enable Layout/TrailingWhitespace
+    end
+  end
 end


### PR DESCRIPTION
Trying to remove common ways to accidentally leak information