### PR TITLE
Introduce RedactedData

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,13 @@ jobs:
       - image: cimg/ruby:<< parameters.ruby-version >>
     steps:
       - checkout
-      - ruby/install-deps:
-          bundler-version: '1.17.2'
-          with-cache: false
-      - ruby/rspec-test
+      - run:
+          name: Which bundler?
+          command: bundle -v
+      - ruby/bundle-install
+      - run:
+          name: RSpec
+          command: bundle exec rake spec
       - run:
           name: Rubocop
           command: bundle exec rubocop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,29 @@
 version: 2.1
 orbs:
-  ruby: circleci/ruby@0.1.2
+  ruby: circleci/ruby@1.1
 
 jobs:
-  build:
+  test:
+    parameters:
+      ruby-version:
+        type: string
     docker:
-      - image: cimg/ruby:2.6.5
-    executor: ruby/default
+      - image: cimg/ruby:<< parameters.ruby-version >>
     steps:
       - checkout
+      - ruby/install-deps:
+          bundler-version: '1.17.2'
+          with-cache: false
+      - ruby/rspec-test
       - run:
-          name: Which bundler?
-          command: bundle -v
-      - ruby/bundle-install
-      - run:
-          name: Run specs
-          command: bundle exec rake spec
+          name: Rubocop
+          command: bundle exec rubocop
+
+workflows:
+  build_and_test:
+    jobs:
+      - test:
+          matrix:
+            parameters:
+              # https://github.com/CircleCI-Public/cimg-ruby
+              ruby-version: ["2.6", "3.1", "3.2"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,8 @@ jobs:
       - image: cimg/ruby:<< parameters.ruby-version >>
     steps:
       - checkout
+      - run:
+          command: bundle lock --add-platform x86_64-linux
       - ruby/install-deps:
           bundler-version: '1.17.2'
           with-cache: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - checkout
       - run:
+          name: "Add platform for Bundler"
+          description: "Normally the platforms lives in Gemfile.lock, but as a gem this repo does not have one, CircleCI fails if there are no platforms"
           command: bundle lock --add-platform x86_64-linux
       - ruby/install-deps:
           bundler-version: '1.17.2'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,10 @@ jobs:
       - image: cimg/ruby:<< parameters.ruby-version >>
     steps:
       - checkout
-      - run:
-          name: Which bundler?
-          command: bundle -v
-      - ruby/bundle-install
-      - run:
-          name: RSpec
-          command: bundle exec rake spec
+      - ruby/install-deps:
+          bundler-version: '1.17.2'
+          with-cache: false
+      - ruby/rspec-test
       - run:
           name: Rubocop
           command: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,12 @@ Style/TrailingCommaInArguments:
 Layout/LineLength:
   Max: 120
 
+# require "pp" in specs is flagged in Ruby 2.6 but not in other ones
+# and doing a point disable gets a "unused lint" warning, so this is easier
+# to disable here
+Lint/RedundantRequireStatement:
+    Enabled: false
+
 Metrics/BlockLength:
   Exclude:
     - "spec/**/*.rb"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [2.0.0] - 2024-01-10
+
+- Add support to redact `Data` objects
+
 ## [1.1.0] - 2021-03-24
 
 - Override `Struct#pretty_print` to keep redacted fields redacted when

--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,5 @@ gemspec
 
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
-gem "rubocop", "~> 1.7"
 gem "rspec_junit_formatter", "~> 0.6"
+gem "rubocop", "~> 1.7"

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ gemspec
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 gem "rubocop", "~> 1.7"
+gem "rspec_junit_formatter", "~> 0.6"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,23 @@ pp config
  url="https://example.com">
 ```
 
+## RedactedData
+
+Redaction is also supported for Ruby's built-in Data class:
+
+```ruby
+Config = RedactedData.define(
+  :username,
+  :password,
+  :timeout,
+  :url,
+  allowed_members: [:username, :timeout]
+)
+
+config = Config.new(username: 'example', password: 'secret', timeout: 5, url: 'https://example.com')
+=> #<data Config username="example" password=[REDACTED] timeout=5>
+```
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/redactable.rb
+++ b/lib/redactable.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# A module that adds redacted functionality to a class
+module Redactable
+  def self.included(mod)
+    class << mod
+      attr_reader :allowed_members
+    end
+  end
+
+  def inspect
+    name_or_nil = self.class.name ? " #{self.class.name}" : nil
+
+    attributes = members.map do |member|
+      members_h = to_h
+      if allowed_members.include?(member)
+        "#{member}=#{members_h[member].inspect}"
+      else
+        "#{member}=[REDACTED]"
+      end
+    end.join(" ")
+
+    "#<#{base_name_for_inspection}#{name_or_nil} #{attributes}>"
+  end
+
+  def allowed_members
+    self.class.allowed_members
+  end
+
+  # Overrides for pp
+  # See https://github.com/ruby/pp/blob/3d925b5688b8226f653127d990a8dce48bced5fe/lib/pp.rb#L379-L391
+  # rubocop:disable all
+  def pretty_print(q)
+    q.group(1, sprintf("#<%s %s", base_name_for_inspection, PP.mcall(self, Kernel, :class).name), '>') {
+      q.seplist(PP.mcall(self, base_type_for_pp, :members), lambda { q.text "," }) {|member|
+        q.breakable
+        q.text member.to_s
+        q.text '='
+        q.group(1) {
+          q.breakable ''
+          members_h = to_h
+          if allowed_members.include?(member)
+            q.pp members_h[member]
+          else
+            q.text "[REDACTED]"
+          end
+        }
+      }
+    }
+  end
+  # rubocop:enable all
+
+  alias_method :to_s, :inspect
+
+  def base_name_for_inspection
+    if is_a? Struct
+      "struct"
+    else
+      "data"
+    end
+  end
+
+  def base_type_for_pp
+    if is_a? Struct
+      Struct
+    else
+      Data
+    end
+  end
+end

--- a/lib/redactable.rb
+++ b/lib/redactable.rb
@@ -11,8 +11,8 @@ module Redactable
   def inspect
     name_or_nil = self.class.name ? " #{self.class.name}" : nil
 
+    members_h = to_h
     attributes = members.map do |member|
-      members_h = to_h
       if allowed_members.include?(member)
         "#{member}=#{members_h[member].inspect}"
       else
@@ -32,13 +32,13 @@ module Redactable
   # rubocop:disable all
   def pretty_print(q)
     q.group(1, sprintf("#<%s %s", base_name_for_inspection, PP.mcall(self, Kernel, :class).name), '>') {
+      members_h = to_h
       q.seplist(PP.mcall(self, base_type_for_pp, :members), lambda { q.text "," }) {|member|
         q.breakable
         q.text member.to_s
         q.text '='
         q.group(1) {
           q.breakable ''
-          members_h = to_h
           if allowed_members.include?(member)
             q.pp members_h[member]
           else

--- a/lib/redacted_data.rb
+++ b/lib/redacted_data.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
+# rubocop:disable Style/Documentation
 # rubocop:disable Style/MultilineIfModifier
-# A sublcass of Data that redacts members by default, and can allow some to be printed
+# A subclass of Data that redacts members by default, and can allow some to be printed
 class RedactedData < Data
   include Redactable
 
@@ -14,3 +15,4 @@ class RedactedData < Data
   end
 end if defined?(Data)
 # rubocop:enable Style/MultilineIfModifier
+# rubocop:enable Style/Documentation

--- a/lib/redacted_data.rb
+++ b/lib/redacted_data.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# rubocop:disable Style/MultilineIfModifier
+# A sublcass of Data that redacts members by default, and can allow some to be printed
+class RedactedData < Data
+  include Redactable
+
+  def self.define(*members, allowed_members: [], &block)
+    super(*members, &block).tap do |data_class|
+      data_class.class_eval do
+        @allowed_members = Array(allowed_members)
+      end
+    end
+  end
+end if defined?(Data)
+# rubocop:enable Style/MultilineIfModifier

--- a/lib/redacted_data.rb
+++ b/lib/redacted_data.rb
@@ -13,6 +13,6 @@ class RedactedData < Data
       end
     end
   end
-end if defined?(Data)
+end if defined?(Data) && Data.respond_to?(:define)
 # rubocop:enable Style/MultilineIfModifier
 # rubocop:enable Style/Documentation

--- a/lib/redacted_struct.rb
+++ b/lib/redacted_struct.rb
@@ -1,23 +1,15 @@
 # frozen_string_literal: true
 
-# A subclass of Struct that redacts members by default, and can allow some to be printed
-class RedactedStruct < Struct
-  VERSION = "1.1.0"
+# Class methods for the Redactable module. When Redactable is included in class that class is
+# extended with these instance methods.
+module RedactableClassMethods
+  attr_reader :allowed_members
+end
 
-  def self.new(*name_and_members, keyword_init: nil, allowed_members: [], &block)
-    super(*name_and_members, keyword_init: keyword_init, &block).tap do |struct_class|
-      struct_class.class_eval do
-        @allowed_members = Array(allowed_members)
-      end
-    end
-  end
-
-  class << self
-    attr_reader :allowed_members
-  end
-
-  def allowed_members
-    self.class.allowed_members
+# A module that adds redacted functionality to a class
+module Redactable
+  def self.included(mod)
+    mod.extend RedactableClassMethods
   end
 
   def inspect
@@ -25,23 +17,25 @@ class RedactedStruct < Struct
 
     attributes = members.map do |member|
       if allowed_members.include?(member)
-        "#{member}=#{self[member].inspect}"
+        "#{member}=#{send(member).inspect}"
       else
         "#{member}=[REDACTED]"
       end
     end.join(" ")
 
-    "#<struct#{name_or_nil} #{attributes}>"
+    "#<#{base_name_for_inspection}#{name_or_nil} #{attributes}>"
   end
 
-  alias_method :to_s, :inspect
+  def allowed_members
+    self.class.allowed_members
+  end
 
   # Overrides for pp
   # See https://github.com/ruby/pp/blob/3d925b5688b8226f653127d990a8dce48bced5fe/lib/pp.rb#L379-L391
   # rubocop:disable all
   def pretty_print(q)
     q.group(1, sprintf("#<struct %s", PP.mcall(self, Kernel, :class).name), '>') {
-      q.seplist(PP.mcall(self, Struct, :members), lambda { q.text "," }) {|member|
+      q.seplist(PP.mcall(self, base_type_for_pp, :members), lambda { q.text "," }) {|member|
         q.breakable
         q.text member.to_s
         q.text '='
@@ -57,4 +51,74 @@ class RedactedStruct < Struct
     }
   end
   # rubocop:enable all
+
+  alias_method :to_s, :inspect
+
+  def base_name_for_inspection
+    if is_a? Struct
+      "struct"
+    elsif is_a? Data
+      "data"
+    end
+  end
+
+  def base_type_for_pp
+    if is_a? Struct
+      Struct
+    elsif is_a? Data
+      Data
+    end
+  end
 end
+
+# A subclass of Struct that redacts members by default, and can allow some to be printed
+class RedactedStruct < Struct
+  include Redactable
+
+  VERSION = "1.1.0"
+
+  def self.new(*name_and_members, keyword_init: nil, allowed_members: [], &block)
+    super(*name_and_members, keyword_init: keyword_init, &block).tap do |struct_class|
+      struct_class.class_eval do
+        @allowed_members = Array(allowed_members)
+      end
+    end
+  end
+end
+
+# rubocop:disable Style/MultilineIfModifier
+# A sublcass of Data that redacts members by default, and can allow some to be printed
+class RedactedData < Data
+  include Redactable
+
+  def self.define(*members, allowed_members: [], &block)
+    super(*members, &block).tap do |data_class|
+      data_class.class_eval do
+        @allowed_members = Array(allowed_members)
+      end
+    end
+  end
+
+  # Overrides for pp
+  # See https://github.com/ruby/pp/blob/3d925b5688b8226f653127d990a8dce48bced5fe/lib/pp.rb#L379-L391
+  # rubocop:disable all
+  def pretty_print(q)
+    q.group(1, sprintf("#<data %s", PP.mcall(self, Kernel, :class).name), '>') {
+      q.seplist(PP.mcall(self, Data, :members), lambda { q.text "," }) {|member|
+        q.breakable
+        q.text member.to_s
+        q.text '='
+        q.group(1) {
+          q.breakable ''
+          if allowed_members.include?(member)
+            q.pp self.send(member)
+          else
+            q.text "[REDACTED]"
+          end
+        }
+      }
+    }
+  end
+  # rubocop:enable all
+end if defined?(Data)
+# rubocop:enable Style/MultilineIfModifier

--- a/lib/redacted_struct.rb
+++ b/lib/redacted_struct.rb
@@ -1,81 +1,13 @@
 # frozen_string_literal: true
 
-# Class methods for the Redactable module. When Redactable is included in class that class is
-# extended with these instance methods.
-module RedactableClassMethods
-  attr_reader :allowed_members
-end
-
-# A module that adds redacted functionality to a class
-module Redactable
-  def self.included(mod)
-    mod.extend RedactableClassMethods
-  end
-
-  def inspect
-    name_or_nil = self.class.name ? " #{self.class.name}" : nil
-
-    attributes = members.map do |member|
-      if allowed_members.include?(member)
-        "#{member}=#{send(member).inspect}"
-      else
-        "#{member}=[REDACTED]"
-      end
-    end.join(" ")
-
-    "#<#{base_name_for_inspection}#{name_or_nil} #{attributes}>"
-  end
-
-  def allowed_members
-    self.class.allowed_members
-  end
-
-  # Overrides for pp
-  # See https://github.com/ruby/pp/blob/3d925b5688b8226f653127d990a8dce48bced5fe/lib/pp.rb#L379-L391
-  # rubocop:disable all
-  def pretty_print(q)
-    q.group(1, sprintf("#<struct %s", PP.mcall(self, Kernel, :class).name), '>') {
-      q.seplist(PP.mcall(self, base_type_for_pp, :members), lambda { q.text "," }) {|member|
-        q.breakable
-        q.text member.to_s
-        q.text '='
-        q.group(1) {
-          q.breakable ''
-          if allowed_members.include?(member)
-            q.pp self[member]
-          else
-            q.text "[REDACTED]"
-          end
-        }
-      }
-    }
-  end
-  # rubocop:enable all
-
-  alias_method :to_s, :inspect
-
-  def base_name_for_inspection
-    if is_a? Struct
-      "struct"
-    elsif is_a? Data
-      "data"
-    end
-  end
-
-  def base_type_for_pp
-    if is_a? Struct
-      Struct
-    elsif is_a? Data
-      Data
-    end
-  end
-end
+require_relative "./redactable"
+require_relative "./redacted_data"
 
 # A subclass of Struct that redacts members by default, and can allow some to be printed
 class RedactedStruct < Struct
   include Redactable
 
-  VERSION = "1.1.0"
+  VERSION = "2.0.0"
 
   def self.new(*name_and_members, keyword_init: nil, allowed_members: [], &block)
     super(*name_and_members, keyword_init: keyword_init, &block).tap do |struct_class|
@@ -85,40 +17,3 @@ class RedactedStruct < Struct
     end
   end
 end
-
-# rubocop:disable Style/MultilineIfModifier
-# A sublcass of Data that redacts members by default, and can allow some to be printed
-class RedactedData < Data
-  include Redactable
-
-  def self.define(*members, allowed_members: [], &block)
-    super(*members, &block).tap do |data_class|
-      data_class.class_eval do
-        @allowed_members = Array(allowed_members)
-      end
-    end
-  end
-
-  # Overrides for pp
-  # See https://github.com/ruby/pp/blob/3d925b5688b8226f653127d990a8dce48bced5fe/lib/pp.rb#L379-L391
-  # rubocop:disable all
-  def pretty_print(q)
-    q.group(1, sprintf("#<data %s", PP.mcall(self, Kernel, :class).name), '>') {
-      q.seplist(PP.mcall(self, Data, :members), lambda { q.text "," }) {|member|
-        q.breakable
-        q.text member.to_s
-        q.text '='
-        q.group(1) {
-          q.breakable ''
-          if allowed_members.include?(member)
-            q.pp self.send(member)
-          else
-            q.text "[REDACTED]"
-          end
-        }
-      }
-    }
-  end
-  # rubocop:enable all
-end if defined?(Data)
-# rubocop:enable Style/MultilineIfModifier

--- a/spec/redacted_data_spec.rb
+++ b/spec/redacted_data_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Style/MultilineIfModifier
 RSpec.describe RedactedData do
   it "supports all the signatures of Data.define" do
     expect(RedactedData.define(:member).new(1)).to be
@@ -89,3 +90,4 @@ RSpec.describe RedactedData do
     end
   end
 end if defined?(RedactedData)
+# rubocop:enable Style/MultilineIfModifier

--- a/spec/redacted_data_spec.rb
+++ b/spec/redacted_data_spec.rb
@@ -88,4 +88,4 @@ RSpec.describe RedactedData do
       # rubocop:enable Layout/TrailingWhitespace
     end
   end
-end
+end if defined?(RedactedData)

--- a/spec/redacted_data_spec.rb
+++ b/spec/redacted_data_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+RSpec.describe RedactedData do
+  it "supports all the signatures of Data.define" do
+    expect(RedactedData.define(:member).new(1)).to be
+
+    data_class_with_block = RedactedData.define(:member) do
+      def some_custom_method
+        100
+      end
+    end
+
+    expect(data_class_with_block.new(1).some_custom_method).to eq(100)
+  end
+
+  it "accepts allowed_members in all the signatures of Data.define" do
+    expect(RedactedData.define(:member, allowed_members: [:member]).new(1)).to be
+
+    data_class_with_block = RedactedData.define(:member, allowed_members: [:member]) do
+      def some_custom_method
+        100
+      end
+    end
+
+    expect(data_class_with_block.new(1).some_custom_method).to eq(100)
+  end
+
+  let(:data_class) do
+    RedactedData.define(
+      :username,
+      :password,
+      :api_key,
+      allowed_members: [:username],
+    )
+  end
+
+  describe ".allowed_members" do
+    it "is the list of redacted fields" do
+      expect(data_class.allowed_members).to eq([:username])
+    end
+  end
+
+  describe "#allowed_members" do
+    it "is the list of redacted fields" do
+      expect(instance.allowed_members).to eq([:username])
+    end
+  end
+
+  let(:instance) do
+    data_class.new(
+      username: "example",
+      password: "super secret",
+      api_key: "123456",
+    )
+  end
+
+  describe "#to_s" do
+    it "redacts sensitive members" do
+      expect(instance.to_s).to eq(
+        '#<data username="example" password=[REDACTED] api_key=[REDACTED]>',
+      )
+    end
+  end
+
+  describe "#inspect" do
+    it "redacts sensitive members" do
+      expect(instance.to_s).to eq(
+        '#<data username="example" password=[REDACTED] api_key=[REDACTED]>',
+      )
+    end
+  end
+
+  describe "#pp/#pretty_inspect" do
+    require "pp"
+
+    it "redacts when pretty printed" do
+      io = StringIO.new
+
+      PP.pp instance, io, 30
+
+      # rubocop:disable Layout/TrailingWhitespace
+      expect(io.string).to eq <<~STR
+        #<data 
+         username="example",
+         password=[REDACTED],
+         api_key=[REDACTED]>
+      STR
+      # rubocop:enable Layout/TrailingWhitespace
+    end
+  end
+end


### PR DESCRIPTION
Ruby 3.2 introduced [Data](https://docs.ruby-lang.org/en/3.2/Data.html). This commit adds support for `RedactedData` where `Data` is available.